### PR TITLE
Set `nearley` filetype for `.ne` files

### DIFF
--- a/ftdetect/nearley.vim
+++ b/ftdetect/nearley.vim
@@ -1,1 +1,2 @@
 autocmd BufNewFile,BufRead *.nearley setfiletype nearley
+autocmd BufNewFile,BufRead *.ne setfiletype nearley


### PR DESCRIPTION
[Nearley grammar files use a `.ne` file extension according to the docs](https://nearley.js.org/docs/grammar). 