### PR TITLE
Improvements: more syntax, Typescript support, installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,27 @@
 # vim-nearley
 
-Vim syntax highlighting for [nearley](https://github.com/hardmath123/nearley).
+Vim syntax highlighting for [nearley](https://github.com/kach/nearley).
 
-If you're using [Pathogen](https://github.com/tpope/vim-pathogen), then you should be able to clone this into your `.vim/bundle/`.
+The syntax determines whether to use Typescript or Javascript depending on, if it finds `^@preprocessor typescript`.
+
+## Install
+
+Using [vim-plug](https://github.com/junegunn/vim-plug) in vimscript
+```vim
+Plug 'tjvr/vim-nearley'
+```
+
+Using [vim-pathogen](https://github.com/tpope/vim-pathogen)
+
+- Clone `tjvr/vim-nearley` into `.vim/bundle/`.
+
+Using [lazy.nvim](https://github.com/folke/lazy.nvim) in lua
+```lua
+"tjvr/vim-nearley",
+```
+
+Using [packer](https://github.com/wbthomason/packer.nvim) in lua
+```lua
+use { "tjvr/vim-nearley" }
+```
+


### PR DESCRIPTION
I've rewritten the syntax to
- support `@preprocessor` and `@lexer` directives, in addition to `@builtin` and `@include`
- fix Javascript support in code blocks. (It didn't work for me before. Setup using `NVIM v0.10.0`)
- conditionally use Typescript, instead of Javascript, by searching for `@preprocessor typescript`
- include all non-terminals and tokens in the syntax
- include all operators, eg. `:?` and `""i`
- include macro arguments, as seperate from char classes
- replace Regexs to be a bit simpler

I've also added installation instructions in the README for Lazy and Packer.

Example in my Neovim configuration using [ellisonleao/gruvbox.nvim](https://github.com/ellisonleao/gruvbox.nvim).
![image](https://github.com/user-attachments/assets/8ce51dc7-6091-4813-bb33-6de4cd5fbd33)

For reference, this is a screenshot using the old syntax:
![image](https://github.com/user-attachments/assets/4fbec90c-468f-4a3b-a76c-a52e7b6aeb89)
